### PR TITLE
Fixed error when no pronunciation is presented

### DIFF
--- a/Kawazu/Division.cs
+++ b/Kawazu/Division.cs
@@ -66,8 +66,15 @@ namespace Kawazu
             switch (type)
             {
                 case TextType.PureKana:
-                    for(var i = 0; i < node.Surface.Length; i++)
-                        Add(new JapaneseElement(node.Surface[i].ToString(), Utilities.ToRawKatakana(node.Surface[i].ToString()), node.Pronounciation[i].ToString(), TextType.PureKana, system));
+                    if (node.Surface.Length == node.Pronounciation.Length)
+                        for (var i = 0; i < node.Surface.Length; i++)
+                            Add(new JapaneseElement(node.Surface[i].ToString(), Utilities.ToRawKatakana(node.Surface[i].ToString()), node.Pronounciation[i].ToString(), TextType.PureKana, system));
+                    else
+                        for (var i = 0; i < node.Surface.Length; i++)
+                        {
+                            var surface = Utilities.ToRawKatakana(node.Surface[i].ToString());
+                            Add(new JapaneseElement(node.Surface[i].ToString(), surface, surface, TextType.PureKana, system));
+                        }
                     break;
                 
                 case TextType.PureKanji:


### PR DESCRIPTION
Fixed error when no pronunciation is presented
For example
「エレン」
![image](https://user-images.githubusercontent.com/42550249/115741144-637d4a80-a387-11eb-8253-5edd3452a5d8.png)
The `Pronunciation` property is empty hence returning array out of index error